### PR TITLE
Add application dashboard navigation and metrics

### DIFF
--- a/quality-hub-frontend-v2/src/pages/ApplicationDetail.jsx
+++ b/quality-hub-frontend-v2/src/pages/ApplicationDetail.jsx
@@ -23,24 +23,20 @@ export function ApplicationDetail(){
         </div>
         <div className="badge">Updated {new Date(app.updatedAt).toLocaleString()}</div>
       </div>
-      <div className="layout" style={{marginTop:12}}>
-        <aside className="sidebar">
-          <NavLink end to={''} className={({isActive})=> 'sideLink'+(isActive?' active':'')}>Overview</NavLink>
-          <NavLink to={'features'} className={({isActive})=> 'sideLink'+(isActive?' active':'')}>Features</NavLink>
-          <NavLink to={'test-design'} className={({isActive})=> 'sideLink'+(isActive?' active':'')}>Test Design</NavLink>
-          <NavLink to={'executions'} className={({isActive})=> 'sideLink'+(isActive?' active':'')}>Executions</NavLink>
-          <NavLink to={'settings'} className={({isActive})=> 'sideLink'+(isActive?' active':'')}>Settings</NavLink>
-        </aside>
-        <main>
-          <Routes>
-            <Route index element={<DashboardTab app={app} />} />
-            <Route path="features" element={<FeaturesTab app={app} />} />
-            <Route path="test-design" element={<TestDesignTab app={app} />} />
-            <Route path="executions" element={<ExecutionsTab app={app} />} />
-            <Route path="settings" element={<SettingsTab app={app} onSaved={setApp} />} />
-          </Routes>
-        </main>
-      </div>
+      <nav className="tabs" style={{marginTop:12}}>
+        <NavLink end to={''} className={({isActive})=> 'tabLink'+(isActive?' active':'')}>Dashboard</NavLink>
+        <NavLink to={'features'} className={({isActive})=> 'tabLink'+(isActive?' active':'')}>Features</NavLink>
+        <NavLink to={'test-design'} className={({isActive})=> 'tabLink'+(isActive?' active':'')}>Test Design</NavLink>
+        <NavLink to={'executions'} className={({isActive})=> 'tabLink'+(isActive?' active':'')}>Test Execution</NavLink>
+        <NavLink to={'settings'} className={({isActive})=> 'tabLink'+(isActive?' active':'')}>Settings</NavLink>
+      </nav>
+      <Routes>
+        <Route index element={<DashboardTab app={app} />} />
+        <Route path="features" element={<FeaturesTab app={app} />} />
+        <Route path="test-design" element={<TestDesignTab app={app} />} />
+        <Route path="executions" element={<ExecutionsTab app={app} />} />
+        <Route path="settings" element={<SettingsTab app={app} onSaved={setApp} />} />
+      </Routes>
     </div>
   )
 }

--- a/quality-hub-frontend-v2/src/pages/ApplicationsList.jsx
+++ b/quality-hub-frontend-v2/src/pages/ApplicationsList.jsx
@@ -10,7 +10,7 @@ function useQuery(){
 
 function Card({app}){
   return (
-    <div className="card cardGlow">
+    <Link to={`/apps/${app.id}`} className="card cardGlow" style={{display:'block'}}>
       <div className="cardHead">
         <div className="cardTitle">{app.name}</div>
         <div className="cardSub">Version {app.version}</div>
@@ -28,9 +28,9 @@ function Card({app}){
           <PassRing value={app.passRate||0} />
           <div className="small">Pass Rate</div>
         </div>
-        <Link to={`/apps/${app.id}`} className="link">Open ➜</Link>
+        <span className="link">Open ➜</span>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/quality-hub-frontend-v2/src/pages/tabs/Dashboard.jsx
+++ b/quality-hub-frontend-v2/src/pages/tabs/Dashboard.jsx
@@ -3,48 +3,78 @@ import { api } from '../../api'
 import { PassRing } from '../../components/PassRing'
 
 export function DashboardTab({app}){
-  const [activity, setActivity] = useState([])
-  const [schema, setSchema] = useState([])
+  const [executions, setExecutions] = useState([])
 
-  useEffect(()=>{
-    api.activity().then(setActivity)
-    api.schema().then(setSchema)
-  },[])
+  useEffect(()=>{ api.listExecutions(app.id).then(setExecutions) }, [app.id])
+
+  const total = executions.length
+  const passed = executions.filter(e => e.status === 'PASSED').length
+  const failed = executions.filter(e => e.status === 'FAILED').length
+  const skipped = executions.filter(e => e.status === 'SKIPPED').length
+  const passRate = total ? Math.round(passed/total*100) : 0
+
+  const grouped = executions.reduce((acc, e) => {
+    const name = e.testCase?.title || `Test ${e.id}`
+    acc[name] = acc[name] || []
+    acc[name].push(e)
+    acc[name].sort((a,b)=> new Date(b.executedAt) - new Date(a.executedAt))
+    return acc
+  }, {})
+
+  const stable = []
+  const stabilizing = []
+  const risk = []
+
+  Object.entries(grouped).forEach(([name, runs]) => {
+    const last5 = runs.slice(0,5).map(r => r.status)
+    if(last5.length < 5) return
+    if(last5.every(s => s === 'PASSED')) stable.push(name)
+    else if(last5.every(s => s === 'FAILED')) risk.push(name)
+    else stabilizing.push(name)
+  })
 
   return (
     <div className="section">
+      <h3>Recent Execution</h3>
       <div className="kpi">
-        <div className="box"><div className="small">Active</div><div style={{fontSize:22,fontWeight:800}}>{app.active ? 'Yes':'No'}</div></div>
-        <div className="box"><div className="small">Test Cases</div><div style={{fontSize:22,fontWeight:800}}>{app.testCases}</div></div>
-        <div className="box"><div className="small">Executions</div><div style={{fontSize:22,fontWeight:800}}>{app.executions}</div></div>
+        <div className="box"><div className="small">Total</div><div style={{fontSize:22,fontWeight:800}}>{total}</div></div>
+        <div className="box"><div className="small">Passed</div><div style={{fontSize:22,fontWeight:800}}>{passed}</div></div>
+        <div className="box"><div className="small">Failed</div><div style={{fontSize:22,fontWeight:800}}>{failed}</div></div>
+        <div className="box"><div className="small">Skipped</div><div style={{fontSize:22,fontWeight:800}}>{skipped}</div></div>
         <div className="box" style={{display:'flex',alignItems:'center',gap:10}}>
-          <PassRing value={app.passRate} /><div><div className="small">Pass Rate</div><div style={{fontSize:18,fontWeight:800}}>{app.passRate}%</div></div>
+          <PassRing value={passRate} />
+          <div><div className="small">Pass Rate</div><div style={{fontSize:18,fontWeight:800}}>{passRate}%</div></div>
         </div>
       </div>
 
-      <h3 style={{marginTop:24}}>Activity Monitor</h3>
-      <table className="table">
-        <thead><tr><th>Time</th><th>Method</th><th>Path</th><th>Status</th><th>Duration</th></tr></thead>
+      <table className="table" style={{marginTop:16}}>
+        <thead><tr><th>Test Case</th><th>Status</th><th>Executed At</th></tr></thead>
         <tbody>
-          {activity.slice(0,50).map(row => (
-            <tr key={row.id}>
-              <td>{new Date(row.ts).toLocaleTimeString()}</td>
-              <td>{row.method}</td>
-              <td>{row.path}</td>
-              <td>{row.status}</td>
-              <td>{row.durationMs} ms</td>
+          {executions.slice(0,5).map(e => (
+            <tr key={e.id}>
+              <td>{e.testCase?.title || e.id}</td>
+              <td>{e.status}</td>
+              <td>{new Date(e.executedAt).toLocaleString()}</td>
             </tr>
           ))}
         </tbody>
       </table>
 
-      <h3 style={{marginTop:24}}>Integration Endpoints</h3>
-      <table className="table">
-        <thead><tr><th>Path</th><th>Methods</th></tr></thead>
-        <tbody>
-          {schema.map((s,i)=>(<tr key={i}><td>{s.path}</td><td>{Array.isArray(s.methods) ? s.methods.join(', ') : s.methods}</td></tr>))}
-        </tbody>
-      </table>
+      <h3 style={{marginTop:24}}>Historical Results</h3>
+      <div style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(200px,1fr))',gap:16}}>
+        <div>
+          <div style={{fontWeight:700}}>Stable</div>
+          <ul>{stable.length ? stable.map(n => <li key={n}>{n}</li>) : <li className="small">No data</li>}</ul>
+        </div>
+        <div>
+          <div style={{fontWeight:700}}>Stabilizing</div>
+          <ul>{stabilizing.length ? stabilizing.map(n => <li key={n}>{n}</li>) : <li className="small">No data</li>}</ul>
+        </div>
+        <div>
+          <div style={{fontWeight:700}}>Risk Zone</div>
+          <ul>{risk.length ? risk.map(n => <li key={n}>{n}</li>) : <li className="small">No data</li>}</ul>
+        </div>
+      </div>
     </div>
   )
 }

--- a/quality-hub-frontend-v2/src/styles.css
+++ b/quality-hub-frontend-v2/src/styles.css
@@ -32,11 +32,11 @@ a{color:inherit; text-decoration:none}
 .value{font-size:22px; font-weight:800}
 .cardFoot{display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-top:1px solid var(--border)}
 .link{display:flex; align-items:center; gap:8px; font-weight:700}
+.tabs{display:flex; gap:12px; border-bottom:1px solid var(--border); margin-top:12px}
+.tabLink{padding:10px 12px; border-bottom:2px solid transparent; color:#cbd5e1}
+.tabLink.active{border-bottom-color:var(--brand-1); color:white}
+.tabLink:hover{color:white}
 .pass{font-weight:800}
-.sidebar{border-right:1px solid var(--border); background:linear-gradient(180deg,#0b1120AA,#060b1bAA); padding:18px; min-height:calc(100vh - 140px)}
-.layout{display:grid; grid-template-columns: 240px 1fr; gap:0}
-.sideLink{display:flex; gap:10px; padding:10px 12px; border-radius:10px; color:#cbd5e1}
-.sideLink.active, .sideLink:hover{background:var(--glass); color:white}
 .section{padding:18px}
 .table{width:100%; border-collapse:collapse}
 .table th,.table td{padding:10px 12px; border-bottom:1px solid var(--border); color:#d7e0ea}


### PR DESCRIPTION
## Summary
- Make application cards clickable and route directly to the dashboard
- Replace sidebar with top navigation tabs and add dashboard metrics
- Introduce test result stability sections and supporting styles

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae2e6c75888321b585fa0aa6bb633d